### PR TITLE
READY UNSTABLE : Break cycle dependency

### DIFF
--- a/proto/wtools/amid/l3/npm/include/Basic.ss
+++ b/proto/wtools/amid/l3/npm/include/Basic.ss
@@ -10,7 +10,7 @@ if( typeof module !== 'undefined' )
   const _ = require( '../../../../../node_modules/Tools' );
   _.include( 'wHttp' );
   _.include( 'wProcess' );
-  _.include( 'wFiles' );
+  _.include( 'wFilesBasic' );
   module[ 'exports' ] = _global_.wTools;
 }
 

--- a/was.package.json
+++ b/was.package.json
@@ -36,7 +36,7 @@
     "wTools": "",
     "wprocess": "",
     "whttp": "",
-    "wFiles": ""
+    "wFilesBasic": ""
   },
   "devDependencies": {
     "wTesting": "",

--- a/will.yml
+++ b/will.yml
@@ -292,8 +292,8 @@ submodule:
   wTools:
     path: 'npm:///wTools'
     enabled: 0
-  wFiles:
-    path: 'npm:///wFiles'
+  wFilesBasic:
+    path: 'npm:///wfilesbasic'
     enabled: 0
   wprocess:
     path: 'npm:///wprocess'


### PR DESCRIPTION
Before accepting, the module `FilesBasic` should be published and module `Files` should be split into low and high parts